### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "gm": "^1.23.1",
     "node-schedule": "^1.3.2",
-    "npm": "^6.9.0",
     "simple-svg-tools": "^1.1.12",
     "twit": "^2.2.11"
   },


### PR DESCRIPTION

Hello Yopaman!

It seems like you have npm as one of your (dev-) dependency in twitter-pp.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
